### PR TITLE
Updated readme/table structure for deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ ALTER TABLE snapshots
   USING data::jsonb;
 ```
 
+In addition, the `snapshots` table might have a `NOT NULL` constraint on the `doc_type` and `data` columns that will need to be dropped, since these are set to null when a ShareDB document is deleted via its `.del()` method.
+
+```PLpgSQL
+ALTER TABLE snapshots
+  ALTER COLUMN doc_type
+  DROP NOT NULL;
+  
+ALTER TABLE snapshots
+  ALTER COLUMN data
+  DROP NOT NULL;
+```
+
 ## Usage
 
 `sharedb-postgres` wraps native [node-postgres](https://github.com/brianc/node-postgres), and it supports the same configuration options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharedb-postgres",
-  "version": "3.0.1-zw",
+  "version": "3.0.2-zw",
   "description": "PostgreSQL adapter for ShareDB",
   "main": "index.js",
   "scripts": {

--- a/structure.sql
+++ b/structure.sql
@@ -9,8 +9,8 @@ CREATE TABLE ops (
 CREATE TABLE snapshots (
   collection character varying(255) not null,
   doc_id character varying(255) not null,
-  doc_type character varying(255) not null,
+  doc_type character varying(255), -- Will be set to null if deleted
   version integer not null,
-  data jsonb not null,
+  data jsonb, -- Will be set to null if deleted
   PRIMARY KEY (collection, doc_id)
 );


### PR DESCRIPTION
- ShareDB sets `doc_type` and `data` to null in the `snapshots` table
when a document is deleted